### PR TITLE
Add beginner Slack tips for students

### DIFF
--- a/docs/students/slack-students.md
+++ b/docs/students/slack-students.md
@@ -67,3 +67,168 @@ You can read more about asking good questions [here](/students/guides/asking-que
 - Make sure to tag students and graduates for events and create user groups for core volunteers
 - Share social meetings and pictures in public channels
 - Summarise meetings in minutes using assigned shared document
+
+## Effective Slack for Beginners
+
+Slack is a powerful messaging platform, rich in features not to mention the myriads of available extensions.
+Here we collected some basic tips and hints for new users how to use it effectively and utilize its capabilities.
+
+**Take note**: The description is based on the user interface in desktop Slack. It varies on different platforms.
+ 
+### Conversation threads
+Threads keep discussions in Slack organized usually within a channel but it also can be used in direct messages.
+They let you ask questions, add context, or give feedback on a specific message, all without disrupting a conversation's flow.
+A thread will remain connected to its original message.
+
+__Why use threads?__
+ * Clearly tie your feedback and thoughts to a specific message or file.
+ * Organize conversations and preserve meaningful context.
+ * Encourage open discussion without distracting others.
+
+To initiate a new thread on a post, hover over the message you'd like to reply to, click the  "_Start a thread_" icon.
+
+See more for [how to use threads](https://slack.com/intl/en-hu/help/articles/115000769927-Use-threads-to-organize-discussions-).
+
+### Mention to grip members' attention
+Sometimes you’ll need to get the attention of another member when having a conversation in Slack.
+When you send a message and include an _@mention_, the person you mention will be notified. 📣
+
+To mention a member or a group, start typing the @ symbol followed by a member’s name that will give you a list of members to choose from.
+When you find the member you want to mention, select their name from the list.
+
+You can also mention user groups if you would like to reach a whole group.
+
+See for more [how to mention members](https://slack.com/intl/en-hu/help/articles/205240127-Mention-a-member).
+
+### Making calls
+Sometimes it helps to talk things out. With Slack calls, you can make a voice or video call to any member of your workspace.
+
+To start a __call from direct message__, open a direct message then click the 📞 phone icon in the top right corner.
+Your call will start right away, and the member you're calling will receive a pop-up notification.
+
+To start a __call from a channel__, open a channel and click "_Details_" in the top right then choose 📞 Call button.
+Slack will post a message to the channel and any member (up to 15 total) can join by clicking the _Join_ button.
+
+See for more [how to about calls](https://slack.com/intl/en-hu/help/articles/216771908-Make-calls-in-Slack).
+
+### Bookmarking messages
+You can save messages and files in Slack to bookmark them and reference them later.
+It helps to revisit them later without delving in the comment tsunami.
+
+To bookmark a post, hover over the post and click the “_Save_" bookmark icon.
+
+To remove a bookmarked item, simply click on the star again, and it will disappear from your list.
+
+To list all saved messages, click on the "_Saved_" menu on the menu bar.
+
+See for more [how to save messages](https://slack.com/intl/en-hu/help/articles/360042650274-Save-messages-and-files-).
+
+### Edit and delete messages
+Quite often we end up sending a wrong message or a message with a typo in a hurry.
+Thankfully, Slack lets us correct or even delete such messages.
+
+In general, you can edit only the messages that you have sent.
+The edited messages will have grayed out Edited label next to them.
+
+To edit or delete a message, hover over the message and click on the three dots icon and select "_Edit message_"
+or "_Delete message_" correspondingly. Once you delete a message, it will be removed for everyone.
+
+> Tip: Use the up arrow key on PC to directly edit recently sent messages.
+
+See for more [how to edit and delete messages](https://slack.com/intl/en-hu/help/search?utf8=%E2%9C%93&query=reminder&commit=Search).
+
+### Direct Message
+Another way to save resources is to share them with yourself!
+By setting up a Direct Message (DM) to yourself you can begin your own personal journal.
+It can be a place for you to save notes, personal to-do lists, documents and more!
+
+To share a post or resource from a channel to yourself simply hover over the post and click the “_Share message_” arrow and send to yourself.
+It will be then saved in your personal DM.
+
+> Tip: Edit your message to cross out tasks that you’ve finished or use an emoji reaction to mark the whole list as complete. ✅
+
+See for more [how to send DM to yourself](https://slack.com/intl/en-gb/help/articles/219899267-Save-notes-and-files-in-your-personal-DM).
+
+### Keep messages for group
+Pin posts or set topic description to keep useful or important messages in view for wider audience in a channel.
+There is a couple of items in the channel header. Among others, you can see already pinned messages or get an overall about the channel.
+
+To pin a message, hover over the post, clik thre three dots icon (“_More actions_”) then select “_Pin to channel_”.
+Unlike starred messages, pinned messages are visible for every member of the channel.
+It works like a public board on the classroom wall.
+
+To set channel topic, hover over the current topic, click the topic to edit it.
+Generally it keeps useful information for the channel members for instance the channel’s purpose, links etc.
+If the topic is too long, it might be trimmed. To see the whole text, hover over the topic.
+
+See for more
+ * [how to pin message](https://slack.com/intl/en-hu/help/articles/205239997-Pin-messages-and-files),
+ * [how to set channel topic](https://slack.com/intl/en-hu/help/articles/201654083-Set-a-channel-topic-or-description).
+
+### View mentions and reactions
+If we have been tagged in a post or someone has added to a thread we were involved in, Slack gives us a notification making it easy to follow along with a discussion.
+
+A way of checking in on posts we have been involved with recently, is to use the “_Mentions & Reactions_” menu on menu bar.
+Here Slack shows us all our recent activity allowing us to find recent replies or reactions to our messages.
+This feature is great as usually Slack does not give us a notification for any reactions to our messages. 
+So to check if someone has left an emoji to your message try checking your activity!
+
+### Reduce noise
+More channels you follow, more distracting they become that can turn to be very fustrating after a while.
+If you need focus time or time away from work, there are many options in Slack to help you concentrate.
+You can pause your notifications using Do Not Disturb (DND) mode, mute channels or conversations, or leave unrelevant channels.
+
+To set DND schedule for routine times you'd prefer not to be notified, click your workspace name in the top left,
+hover over "_Pause notifications_", choose a time frame from the menu or select Custom to set your own.
+
+To mute channels, right click the channel you’d like to mute and select "_Mute channel_".
+Muted channels will be greyed out at the bottom of the sidebar list.
+
+See for more technics on [how to reduce noise](https://slack.com/intl/en-hu/help/articles/218551977-Reduce-noise-in-Slack).
+
+### Reminder
+Busy as a bee, or maybe feeling a little forgetful?
+Send reminders to yourself for important messages, events or anything you might need to come back to later.
+
+To create a reminder to a post, hover the post and click the three dots icon (“_More actions_”)
+then select "_Remind me about this_" to remind yourself to come back to it later.
+
+To create a general reminder, simply open the ⚡ shortcuts menu to set reminder for yourself.
+
+See for more [how to set reminder](https://slack.com/intl/en-hu/help/articles/208423427-Set-a-reminder).
+
+### Search
+Accessing the right information in Slack is key to working smarter, faster, and more productively.
+
+Click the 🔍 search field in the top right to open the search window, 
+type what you are looking for into the search field, and optionally add [_modifiers_](#search modifier) to narrow the scope.
+Slack will suggest relevant channels, files, and recent searches. Choose a suggested option in the list to open it.
+
+#### Search modifier
+
+Modifiers help narrow the scope of what you are looking for, so you can find information faster.
+You can also combine more modifiers together to get a more specific search result.
+ * Use ```from:@Name``` to find text shared by someone, e.g.: ```from:@Sarah homework```
+ * Use ```in:#Channel``` to find text in a specific channel, e.g.: ```in:#class-3```
+
+See for more [search and modifiers](https://slack.com/intl/en-hu/help/articles/202528808-Search-in-Slack).
+
+### One-click responses and approvals: Say it with emoji
+Emoji can be a lot of fun, but we also use them as reactions all the time to speed up work.
+Watch for opportunities to use reactions in place of short messages that might otherwise clutter conversations in a channel.
+
+Here are some example.
+ - 👍= “Acknowledgement I’ve seen your message”, “I agree” or “I'm in”
+ - ✅or ✔ = “Approved” or “I finished the training”
+ - ➕or 💯= “I agree”
+ - 👏= “Great job!” or “Well done!”
+
+Same emoji can have different meaning depending on the context.
+
+### Adjust zoom level
+If the text size strains your eyes to read it, you can adjust your zoom leve
+to make the app and text display larger or even smaller.
+
+To adjust zoom level, click your workspace name, choose "_Preferences_" then click "_Click Accessibility_" and finally select your zoom level.
+
+See for more [how to adjust zoom level](https://slack.com/intl/en-hu/help/articles/236067467-Adjust-your-zoom-level-in-Slack).


### PR DESCRIPTION
I'd like to extend the current Slack documentation for students with tips for beginners.
I'm positioning the level somewhere between the fundamentals and advanced functions that would be useful after the Introductory Slack exercise.

It is also useful for dropping one-one tip with students along with the curse, to train and keep them engaged.