### PR TITLE
Add React cheatsheet to docs

### DIFF
--- a/docs/students/guides/react-cheatsheet.md
+++ b/docs/students/guides/react-cheatsheet.md
@@ -1,0 +1,5 @@
+# React Cheatseat
+
+This is a temporarily link to the [React Cheatsheet on Google Docs](https://docs.google.com/document/d/1Y2vCGZ6BZu4yix6EaU--67DfRrTbc6n_dwjbJ7n6kz4/edit?usp=sharing).
+
+This will be added as an inline document in this syllabus once the content has been finalised.

--- a/docs/students/guides/react-cheatsheet.md
+++ b/docs/students/guides/react-cheatsheet.md
@@ -1,3 +1,8 @@
+---
+id: react-cheatsheet
+title: React Cheatsheet
+---
+
 # React Cheatseat
 
 This is a temporarily link to the [React Cheatsheet on Google Docs](https://docs.google.com/document/d/1Y2vCGZ6BZu4yix6EaU--67DfRrTbc6n_dwjbJ7n6kz4/edit?usp=sharing).


### PR DESCRIPTION
# What does this change?
Adds React Cheatsheet temporarily link document to guides.

## Description

[Rendered version](https://github.com/CodeYourFuture/wiki/tree/react-cheatsheet-to-docs/docs/students/guides/react-cheatsheet.md)

@nbogie 

