### PR TITLE
sidebars.json: link Sub's react-cheatsheet

### DIFF
--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -13,7 +13,8 @@
       "students/guides/hosting-netlify",
       "students/guides/node",
       "students/guides/cors",
-      "students/guides/creating-a-react-app"
+      "students/guides/creating-a-react-app",
+      "students/guides/react-cheatsheet"      
     ],
     "Soft Skills Guides": ["students/getting-a-job", "students/slack-students"],
     "FAQs": ["students/faqs"]


### PR DESCRIPTION
Hi Sub, see this change to `sidebars.json` for how to link to a page from the wiki sidebar.  

Pages don't otherwise get surfaced at all, i think...
