### PR TITLE
Reformat personal development roles page

### DIFF
--- a/docs/volunteers/personaldevelopment/pd-roles.md
+++ b/docs/volunteers/personaldevelopment/pd-roles.md
@@ -5,30 +5,28 @@ title: Roles
 
 There are several roles that you can take when volunteering with the Personal Development Team which have varying levels of time commitment and planning.
 
-PD Core team - Organising group for each city's Personal Development team
+## Core PD Team
 
-6-8 people (1 person per 5 students in each class, plus 1 for the mentoring program, and support for graduates needing employment)
+Organising group for each city's Personal Development team.
 
-Time commitment: 4-10 hours per week for duration of course 
+**Time commitment:** 4-10 hours per week for the duration of the course  
+**Size:** 6-8 people (1 person per 5 students in each class, plus 1 for the mentoring program, and support for graduates needing employment)
 
-Develop the strategy for student learning and support (overarching goals of removing barriers to student’s learning; supporting students development of soft skills)
+### Responsibilities
 
-Meet weekly to plan, share student challenges and give support to each other (face to face video calls)
+- Develop the strategy for student learning and support (overarching goals of removing barriers to student’s learning; supporting students development of soft skills)
+- Meet weekly to plan, share student challenges and give support to each other (face to face video calls)
+- One member supports on coordinating new volunteers and funnels them to appropriate roles in PD
+- One member supports on coordinating the Mentoring Program
+- As a team, assess each applicant shortlisted for the course by the Education Team to see if they qualify based on their personal circumstances
+- Each member supports a group of 4-5 students for the duration of the course
 
-One member supports on coordinating new volunteers and funnels them to appropriate roles in PD
-
-One member supports on coordinating the Mentoring Program
-
-As a team, assess each applicant shortlisted for the course by the Education Team to see if they qualify based on their personal circumstances
-
-Each member supports a group of 4-5 students for the duration of the course
-
-Team coordinates all the PD support for the course:
+**Team coordinates all the PD support for the course:**
 
 PD workshop days (6 sessions throughout the course designed to develop skills needed in the workplace: communication, teamwork, time management, willingness to learn and get feedback)
-  
+
 Weekly online support (check in with students, encourage online communication skills)
-  
+
 Financial support (transport costs, childcare, lunch on class days)
 
 Laptops (donated from corporate partners, loaned until students get a job)
@@ -44,7 +42,7 @@ Employment support (finding roles with employers interested in hiring CYF gradua
 
 Workshops and events hosted by partners (CV writing, mock interviews, general recruitment talks, office visits)
 
-Signposting to other services (don’t need to be an expert in everything but need to know where to get additional support eg. housing or legal) 
+Signposting to other services (don’t need to be an expert in everything but need to know where to get additional support eg. housing or legal)
 
 Design content and deliver PD workshop days
 
@@ -54,102 +52,69 @@ Work closely with the Education team to track student progress
 
 Support during the technical classes with the icebreaker/energiser; student expenses; meeting with and giving student’s feedback
 
+## General PD Volunteer Roles
 
-General PD Volunteer
+Time commitment varies depending on the role
 
-Time commitment: varies depending on the role
+### Applicant Calling
 
-Role: Applicant Calling 
+Support applicants during the application process.
 
-Time commitment: 1 hour to become familiar with the stages of the application process and what the student is required to do; then 1 - 2 hours of calling a set number of applicants who have not completed steps, updating list with feedback on what was learned in the calls. Can be one off or ongoing. 
+**Time commitment:** 1 hour to become familiar with the stages of the application process and what the student is required to do; then 1 - 2 hours of calling a set number of applicants who have not completed steps, updating list with feedback on what was learned in the calls. Can be one off or ongoing.
 
-Description: 
+- Call course applicants during the application process
+- Provide support on the application process
+- Answer questions and find blockers which are stopping progress with applications
 
-Calling course applicants during the application process. Give support on the application process, answer questions, find any blockers which are stopping them from progressing with their application. 
-
-Role: Applicant Drop in Days 
+### Applicant Drop-in Days
 
 Support CYF team on applicant drop in days by assessing the personal circumstances of applicants.
 
-Time commitment: the duration of the drop in session 2-6 hours. Can be one off or ongoing
+**Time commitment:** The duration of the drop in session 2-6 hours. Can be one-off or ongoing.
 
-Description:
+- Find out if anyone needs a laptop to move to next step of the application process.
+- If anyone needs transport costs paid for drop in sessions or for the course if they are accepted.
+- If anyone has children and needs childcare for the drop in sessions or the classes if they are accepted.
+- If anyone needs internet provided in their home or via a Wifi dongle.
+- If anyone seems to have difficulty reading or speaking English.
 
-Find out if anyone needs a laptop to move to next step of the application process. 
-
-If anyone needs transport costs paid for drop in sessions or for the course if they are accepted. 
-
-If anyone has children and needs childcare for the drop in sessions or the classes if they are accepted.
-
-If anyone needs internet provided in their home or via a Wifi dongle. 
-
-If anyone seems to have difficulty reading or speaking English. 
-
-Role: Applicant Interview Days 
-
-Time commitment: 1 hour per interview plus time to become familiar with the Interview Questionnaire and Applicant criteria document
-
-Description:
+### Applicant Interview Days
 
 Interview Applicants from a non technical point of view.
 
-Assess if the student meets the minimum application criteria (link) 
+**Time commitment:** 1 hour per interview plus time to become familiar with the Interview Questionnaire and Applicant criteria document
 
-Assess their language ability from their 300 word Personal Statement. 
+- Assess if the student meets the minimum application criteria (link)
+- Assess their language ability from their 300 word Personal Statement.
+- Assess their ability to commit 25 hours a week to the course.
+- Check if they are studying anywhere else.
+- Check if they have a very long commute to the class space. Check if they have caring responsibilities.
+- Check if they are employed P/T or F/T or casual.
+- Confirm they have a bank account so we can pay for their expenses.
+- Consult with the technical interviewer and make an assessment of the student’s potential to complete the course.
+- Fill out the Interviewers Feedback Form.
 
-Assess their ability to commit 25 hours a week to the course. 
+### PD Workshop Facilitator
 
-Check if they are studying anywhere else. 
+Volunteer for the whole day to support the various PD activities being delivered.
+2-4 days during Fundamentals course; 5-6 days during main course.
 
-Check if they have a very long commute to the class space. Check if they have caring responsibilities. 
+**Time commitment:** 7-8 hours; no preparation needed. One-off.  
+**Time commitment:** 3-4 hours on the workshop day; some preparation needed to create content and communicate support needed before session day  
+**Time commitment:** Volunteer to lead on delivering a 1-2 hour session
 
-Check if they are employed P/T or F/T or casual. 
+### Career Mentor
 
-Confirm they have a bank account so we can pay for their expenses. 
+Support one student with help on their career journey for the duration of the course 6-8 months. No support with technical homework or questions.
 
-Consult with the technical interviewer and make an assessment of the student’s potential to complete the course.
+**Time commitment:** 3 hours per month for duration of the course
 
-Fill out the Interviewers Feedback Form. 
-
-Role: PD Workshop Facilitator 2- 4 days during Fundamentals course; 5-6 days during main course
-
-Time commitment: 7-8 hours; no preparation needed. One off. 
-
-Description:
-
-Volunteer for the whole day to support the various PD activities being delivered 
-
-or
-
-Time commitment: 3-4 hours on the workshop day; some preparation needed to create content and communicate support needed before session day
-
-Description:
-
-Volunteer to lead on delivering a 1-2 hour session 
-
-Role: Career Mentor 
-
-Time commitment: 3 hours per month for duration of the course
-
-Description:
-
-Support one student with help on their career journey for the duration of the course 6-8 months. No support with technical homework or questions. 
-
-Complete Lumina Spark questionnaire (15 - 20 mins)
-
-Attend mentoring induction workshop (One Saturday or Sunday, 7-8 hours) 
-
-Meet with mentee face to face (1 hour at start of mentoring program) 
-
-Meet with mentee via video call, Slack  (1-1.5 hours per month, can meet more if agreed with mentee)
-
-Fill in mentoring feedback form (15 mins once per month) 
-
-Join mentoring Slack group for support (ask questions and contribute suggestions when able) 
-
-Join mentoring feedback call (once every 3 months for 1 hour)
-
-Review student CVs
-
-Facilitate mock interviews for students
-
+- Complete Lumina Spark questionnaire (15 - 20 mins)
+- Attend mentoring induction workshop (One Saturday or Sunday, 7-8 hours)
+- Meet with mentee face to face (1 hour at start of mentoring program)
+- Meet with mentee via video call, Slack (1-1.5 hours per month, can meet more if agreed with mentee)
+- Fill in mentoring feedback form (15 mins once per month)
+- Join mentoring Slack group for support (ask questions and contribute suggestions when able)
+- Join mentoring feedback call (once every 3 months for 1 hour)
+- Review student CVs
+- Facilitate mock interviews for students


### PR DESCRIPTION
Very quick and rough reformat of the PD page to make it easier to digest. Would appreciate any feedback on the contents as I really didn't have the context to make any express changes.

Main concern is the ambiguous `PD Workshop Facilitator` role and it's three different time commitments that I am unsure make much sense in this format.